### PR TITLE
Readabillity fixes

### DIFF
--- a/onedrive.spec
+++ b/onedrive.spec
@@ -13,8 +13,11 @@ Patch0: onedrive-copr.patch
 License: GPL
 Group: System Environment/Daemons
 Buildroot: /var/tmp/%{name}-%{version}-%{release}-root
-BuildRequires: ldc sqlite-devel libcurl-devel
-Requires: libcurl sqlite
+BuildRequires: ldc
+BuildRequires: sqlite-devel
+BuildRequires: libcurl-devel
+Requires: libcurl
+Requires: sqlite
 Requires(post): systemd
 Requires(preun): systemd 
 

--- a/onedrive.spec
+++ b/onedrive.spec
@@ -1,25 +1,25 @@
-%define name onedrive
-%define debug_package %{nil}
-%define version gitvers
-%define release 1
+%define          name onedrive
+%define          debug_package %{nil}
+%define          version gitvers
+%define          release 1
 
-Summary: A complete tool to interact with OneDrive on Linux. Built following the UNIX philosophy.
-Name: %{name}
-Version: %{version}
-Release: %{release}
-Vendor: Patrick Pichon <patrick@pichon.me>
-Source: https://github.com/skilion/onedrive.tar
-Patch0: onedrive-copr.patch
-License: GPL
-Group: System Environment/Daemons
-Buildroot: /var/tmp/%{name}-%{version}-%{release}-root
-BuildRequires: ldc
-BuildRequires: sqlite-devel
-BuildRequires: libcurl-devel
-Requires: libcurl
-Requires: sqlite
-Requires(post): systemd
-Requires(preun): systemd 
+Summary:         A complete tool to interact with OneDrive on Linux. Built following the UNIX philosophy.
+Name:            %{name}
+Version:         %{version}
+Release:         %{release}
+Vendor:          Patrick Pichon <patrick@pichon.me>
+Source:          https://github.com/skilion/onedrive.tar
+Patch0:          onedrive-copr.patch
+License:         GPL
+Group:           System Environment/Daemons
+Buildroot:       /var/tmp/%{name}-%{version}-%{release}-root
+BuildRequires:   ldc
+BuildRequires:   sqlite-devel
+BuildRequires:   libcurl-devel
+Requires:        libcurl
+Requires:        sqlite
+Requires(post):  systemd
+Requires(preun): systemd
 
 %description
 A complete tool to interact with OneDrive on Linux. Built following the UNIX philosophy.


### PR DESCRIPTION
For easy reading of the spec file, it should have one (Build)Requires per line. (In mageia that is required by policy.) This makes it easier to see what is actually required to build it.
It should also be indented.

I have fixed this, which will make it easier to read.